### PR TITLE
Fix typo

### DIFF
--- a/c/scribblings/eval.scrbl
+++ b/c/scribblings/eval.scrbl
@@ -11,7 +11,7 @@
 
 @title[#:tag "eval"]{Evaluation}
 
-This library provides utilities for building and runnign C programs with
+This library provides utilities for building and running C programs with
 a system-installed C compiler. Currently the only supported compiler is
 @link["http://gcc.gnu.org"]{GCC}.
 


### PR DESCRIPTION
`s/runnign/running/`

I have submitted this on dhermann repo as well but it starts to look like yours the go-to repo.