### PR TITLE
Remove bold formatting from Scribble title

### DIFF
--- a/c/scribblings/c-utils.scrbl
+++ b/c/scribblings/c-utils.scrbl
@@ -3,7 +3,7 @@
 @require[scribble/manual
          scribble/basic]
 
-@title[#:tag "top"]{@bold{C} Metaprogramming Utilities}
+@title[#:tag "top"]{C Metaprogramming Utilities}
 
 by @author+email["Dave Herman" "dherman@ccs.neu.edu"]
 


### PR DESCRIPTION
For visual consistency with other packages within the docs